### PR TITLE
[poro] step-1 : 모든 Request Header 출력, index.html 뷰 매핑

### DIFF
--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,14 @@
 package webserver;
 
+import java.io.BufferedReader;
 import java.io.DataOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.nio.file.Files;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,9 +27,22 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-            // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
+            BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
+
+            String requestLine = br.readLine();
+            logger.debug("request line : {}", requestLine);
+            String requestHeader;
+            while (!(requestHeader = br.readLine()).equals("")) {
+                logger.debug("header : {}", requestHeader);
+            }
+            //Request Tokenizer
+            String[] requestTokens = requestLine.split(" ");
+            //Path 추출
+            String requestUrl = requestTokens[1];
+
+            //Data 출력
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "Hello World".getBytes();
+            byte[] body = Files.readAllBytes(new File("src/main/resources/templates"+requestUrl).toPath());
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {
@@ -35,6 +52,7 @@ public class RequestHandler implements Runnable {
 
     private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
         try {
+            //헤더 작성
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
             dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");


### PR DESCRIPTION
## 구현 내용
- 클라이언트에서 Request 보낼 때 서버가 받는 모든 Request Header의 로그를 출력
- Request의 url을 파싱하여 해당하는 뷰의 정적 파일 뷰를 반환하도록 구현

## 고민 사항
- 루트 URL로 접속 시 Mapping이 안되어있음
- Request Handler가 점점 비대해져 다음 단계에서는 Request 파싱을 위한 Utils을 따로 분리하겠습니다.
- Request Mapping에 대한 로직도 Spring처럼 Controller로 분리하면 좋을 것 같습니다.(다음 단계에 분리 예정)
- HttpRequest 타입을 구현해서 메소드, 쿼리파라미터, URL을 저장하도록 구현 예정입니다.