### PR TITLE
[poro] step3 피드백 반영 및 리팩터링 : ContentType 개선, UrlMapper, View, ViewResolver

### DIFF
--- a/src/main/java/controller/UrlMapper.java
+++ b/src/main/java/controller/UrlMapper.java
@@ -1,0 +1,29 @@
+package controller;
+
+import request.HttpRequest;
+
+public class UrlMapper {
+    private UserController userController;
+
+    public UrlMapper(UserController userController) {
+        this.userController = userController;
+    }
+
+    /**
+     * HTTP Request를 받아 요청 URL을 분석해 비즈니스 로직을 수행하고 뷰를 String으로 반환합니다.
+     * @param httpRequest
+     * @return view
+     */
+    public String requestMapping(HttpRequest httpRequest) {
+        if (httpRequest.getUrl().equals("/")) {
+            httpRequest.setUrl("/index.html");
+            return httpRequest.getUrl();
+        }
+
+        if (httpRequest.getUrl().equals("/user/create")) {
+            return userController.userJoin(httpRequest);
+        }
+
+        return httpRequest.getUrl();
+    }
+}

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -7,25 +7,6 @@ import request.HttpRequest;
 
 public class UserController {
     /**
-     * HTTP Request를 받아 요청 URL을 분석해 비즈니스 로직을 수행하고 뷰를 String으로 반환합니다.
-     * @param httpRequest
-     * @return view
-     */
-
-    public String requestMapping(HttpRequest httpRequest) {
-        if (httpRequest.getUrl().equals("/")) {
-            httpRequest.setUrl("/index.html");
-            return httpRequest.getUrl();
-        }
-
-        if (httpRequest.getUrl().equals("/user/create")) {
-            return userJoin(httpRequest);
-        }
-
-        return httpRequest.getUrl();
-    }
-
-    /**
      * httpRequest의 쿼리 파라미터 map을 넘겨받아 User 객체를 생성합니다.
      * DB와의 연결은 아직 구현되지 않았습니다.
      * 회원 가입 후 home으로 redirect하는 view를 리턴합니다.
@@ -33,7 +14,7 @@ public class UserController {
      * @return view
      */
 
-    private String userJoin(HttpRequest httpRequest) {
+    public String userJoin(HttpRequest httpRequest) {
         Map<String, String> params = httpRequest.getParams();
         User user = new User(params.get("userId"), params.get("password"), params.get("name"),
                 params.get("email"));

--- a/src/main/java/response/ContentsType.java
+++ b/src/main/java/response/ContentsType.java
@@ -19,11 +19,6 @@ public enum ContentsType {
         this.locatedPath = locatedPath;
     }
 
-    ContentsType(String contentType, String locatedPath) {
-        this.contentType = contentType;
-        this.locatedPath = locatedPath;
-    }
-
     public String getContentType() {
         return contentType;
     }

--- a/src/main/java/response/ContentsType.java
+++ b/src/main/java/response/ContentsType.java
@@ -1,18 +1,36 @@
 package response;
 
 public enum ContentsType {
-    HTML("text/html;charset=utf-8"),
-    CSS("text/css;charset=utf-8"),
-    JS("application/javascript"),
-    FONTS("application/octet-stream");
+
+    CSS("text/css;charset=utf-8", "src/main/resources/static", "/css"),
+    JS("application/javascript", "src/main/resources/static", "/js"),
+    FONTS("application/octet-stream", "src/main/resources/static", "/fonts"),
+    HTML("text/html;charset=utf-8", "src/main/resources/templates", "");
 
     private String contentType;
+    private String locatedPath;
+    private String identifier;
 
-    ContentsType(String contentType) {
+    ContentsType(String contentType, String locatedPath, String identifier) {
         this.contentType = contentType;
+        this.identifier = identifier;
+        this.locatedPath = locatedPath;
+    }
+
+    ContentsType(String contentType, String locatedPath) {
+        this.contentType = contentType;
+        this.locatedPath = locatedPath;
     }
 
     public String getContentType() {
         return contentType;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public String getLocatedPath() {
+        return locatedPath;
     }
 }

--- a/src/main/java/response/ContentsType.java
+++ b/src/main/java/response/ContentsType.java
@@ -2,10 +2,12 @@ package response;
 
 public enum ContentsType {
 
-    CSS("text/css;charset=utf-8", "src/main/resources/static", "/css"),
-    JS("application/javascript", "src/main/resources/static", "/js"),
-    FONTS("application/octet-stream", "src/main/resources/static", "/fonts"),
-    HTML("text/html;charset=utf-8", "src/main/resources/templates", "");
+    CSS("text/css;charset=utf-8", "src/main/resources/static", ".*\\.css"),
+    JS("application/javascript", "src/main/resources/static", ".*\\.js"),
+    FONTS("application/octet-stream", "src/main/resources/static", ".*\\.woff$|.*\\.woff2$.*\\.woff3$"),
+    PNG("image/png", "src/main/resources/static", ".*\\.png"),
+    ICO("image/avif", "src/main/resources/templates",".*\\.ico"),
+    HTML("text/html;charset=utf-8", "src/main/resources/templates", ".*\\.html");
 
     private String contentType;
     private String locatedPath;

--- a/src/main/java/response/HttpHeaders.java
+++ b/src/main/java/response/HttpHeaders.java
@@ -10,11 +10,16 @@ public class HttpHeaders {
         this.headers = headers;
     }
 
+    public void put(String key, String value) {
+        headers.put(key, value);
+    }
+
     @Override
     public String toString() {
         StringBuffer headerString = new StringBuffer();
         headers.entrySet().stream()
-                .forEach(e -> headerString.append(e.getKey()).append(": ").append(e.getValue()).append("\r\n"));
+            .forEach(e -> headerString.append(e.getKey()).append(": ").append(e.getValue())
+                .append("\r\n"));
 
         return headerString.append("\r\n").toString();
     }

--- a/src/main/java/response/HttpResponse.java
+++ b/src/main/java/response/HttpResponse.java
@@ -16,6 +16,9 @@ public class HttpResponse {
         this.httpHeaders = httpHeaders;
     }
 
+    public void setHttpHeaders(int contentLength) {
+        httpHeaders.put("Content-Length", String.valueOf(contentLength));
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/response/HttpResponse.java
+++ b/src/main/java/response/HttpResponse.java
@@ -7,32 +7,19 @@ package response;
 public class HttpResponse {
 
     String httpVersion;
-    String status;
-    String statusMessage;
+    Status status;
     HttpHeaders httpHeaders;
 
-    public HttpResponse(String httpVersion, String status, String statusMessage, HttpHeaders httpHeaders) {
+    public HttpResponse(String httpVersion, Status status, HttpHeaders httpHeaders) {
         this.httpVersion = httpVersion;
         this.status = status;
-        this.statusMessage = statusMessage;
         this.httpHeaders = httpHeaders;
     }
 
-    /**
-     * Response의 첫 줄을 return합니다.
-     * @return responseHeadLine
-     */
-    public String getHeadLine() {
-        return String.join(" ", httpVersion, status, statusMessage);
-    }
-
-    public String getHeaders() {
-        return httpHeaders.toString();
-    }
 
     @Override
     public String toString() {
-        String headLine = String.join(" ", httpVersion, status, statusMessage);
+        String headLine = String.join(" ", httpVersion, status.getStatusCode(), status.getStatusMessage());
         return headLine + "\r\n" + httpHeaders;
     }
 }

--- a/src/main/java/response/Status.java
+++ b/src/main/java/response/Status.java
@@ -1,0 +1,22 @@
+package response;
+
+public enum Status {
+    OK("200", "OK"),
+    FOUND("302", "FOUND");
+
+    private String statusCode;
+    private String statusMessage;
+
+    Status(String statusCode, String statusMessage) {
+        this.statusCode = statusCode;
+        this.statusMessage = statusMessage;
+    }
+
+    public String getStatusCode() {
+        return statusCode;
+    }
+
+    public String getStatusMessage() {
+        return statusMessage;
+    }
+}

--- a/src/main/java/view/View.java
+++ b/src/main/java/view/View.java
@@ -1,0 +1,48 @@
+package view;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import response.ContentsType;
+import response.HttpResponse;
+import response.Status;
+
+public class View {
+
+    private String viewName;
+    private ContentsType contentsType;
+    private HttpResponse httpResponse;
+
+    public View(String viewName, ContentsType contentsType, HttpResponse httpResponse) {
+        this.viewName = viewName;
+        this.contentsType = contentsType;
+        this.httpResponse = httpResponse;
+    }
+
+    public View(String viewName, HttpResponse httpResponse) {
+        this.viewName = viewName;
+        this.httpResponse = httpResponse;
+    }
+
+    public byte[] render() throws IOException {
+        byte[] headers = writeHeaderBytes(httpResponse);
+        byte[] body = Files.readAllBytes(
+            new File(contentsType.getLocatedPath() + viewName).toPath());
+        setContentLength(body.length);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        outputStream.write(headers);
+        outputStream.write(body);
+
+        return outputStream.toByteArray();
+    }
+
+    public void setContentLength(int bodyLength) {
+        httpResponse.setHttpHeaders(bodyLength);
+    }
+
+    private byte[] writeHeaderBytes(HttpResponse httpResponse) {
+        return httpResponse.toString().getBytes();
+    }
+}

--- a/src/main/java/view/View.java
+++ b/src/main/java/view/View.java
@@ -25,6 +25,12 @@ public class View {
         this.httpResponse = httpResponse;
     }
 
+    /**
+     * httpResponse에서 header 정보를 읽어와 첫 줄과 header 메시지를 작성하고,
+     * viewName으로 파일 경로에 있는 파일의 Body와 합쳐 반환한다.
+     * @return httpResponseMessage
+     * @throws IOException
+     */
     public byte[] render() throws IOException {
         byte[] headers = writeHeaderBytes(httpResponse);
         byte[] body = Files.readAllBytes(

--- a/src/main/java/view/ViewResolver.java
+++ b/src/main/java/view/ViewResolver.java
@@ -12,37 +12,35 @@ import response.Status;
 public class ViewResolver {
 
     /**
-     * View의 위치에 있는 파일을 찾아 HTTP 응답으로 보냅니다.
+     * View 이름을 인자로 받아 Response를 작성합니다.
      *
      * @param out
      * @throws IOException
      */
 
-    public byte[] mapView(OutputStream out, String viewName) throws IOException {
-        View view;
+    public byte[] mapView(String viewName) throws IOException {
         //Redirect 키워드가 있는 경우 redirect 헤더로 작성
         if (viewName.startsWith("redirect:")) {
-            String redirectView = viewName.replace("redirect:", "");
+            String redirectViewName = viewName.replace("redirect:", "");
 
-            view = new View(redirectView, new HttpResponse("HTTP/1.1", Status.FOUND,
-                new HttpHeaders(Map.of("Location", redirectView))));
-            return view.render();
+            View redirectView = new View(redirectViewName, new HttpResponse("HTTP/1.1", Status.FOUND,
+                new HttpHeaders(Map.of("Location", redirectViewName))));
+            return redirectView.render();
         }
 
         //그 외의 경우 200 OK 응답을 반환
         ContentsType contentsType = mapTypeByIndentifier(viewName);
         Map<String, String> header = new HashMap<>();
         header.put("Content-Type", contentsType.getContentType());
-        view = new View(viewName, contentsType, new HttpResponse("HTTP/1.1", Status.OK,
+        View okView = new View(viewName, contentsType, new HttpResponse("HTTP/1.1", Status.OK,
             new HttpHeaders(header)));
 
-        return view.render();
+        return okView.render();
     }
 
 
     /**
-     * css, js, fonts는 static 폴더에서 파일을 탐색하여 반환합니다. (content header를 text/css로 변경해서 보냅니다.) 나머지(html
-     * 파일)는 templates 폴더에서 탐색합니다.
+     * viewName의 파일 확장자를 기준으로 일치하는 content-type을 반환합니다.
      *
      * @param view
      * @return

--- a/src/main/java/view/ViewResolver.java
+++ b/src/main/java/view/ViewResolver.java
@@ -1,0 +1,61 @@
+package view;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import response.ContentsType;
+import response.HttpHeaders;
+import response.HttpResponse;
+import response.Status;
+
+public class ViewResolver {
+
+    /**
+     * View의 위치에 있는 파일을 찾아 HTTP 응답으로 보냅니다.
+     *
+     * @param out
+     * @throws IOException
+     */
+
+    public byte[] mapView(OutputStream out, String viewName) throws IOException {
+        View view;
+        //Redirect 키워드가 있는 경우 redirect 헤더로 작성
+        if (viewName.startsWith("redirect:")) {
+            String redirectView = viewName.replace("redirect:", "");
+
+            view = new View(redirectView, new HttpResponse("HTTP/1.1", Status.FOUND,
+                new HttpHeaders(Map.of("Location", redirectView))));
+            return view.render();
+        }
+
+        //그 외의 경우 200 OK 응답을 반환
+        ContentsType contentsType = mapTypeByIndentifier(viewName);
+        Map<String, String> header = new HashMap<>();
+        header.put("Content-Type", contentsType.getContentType());
+        view = new View(viewName, contentsType, new HttpResponse("HTTP/1.1", Status.OK,
+            new HttpHeaders(header)));
+
+        return view.render();
+    }
+
+
+    /**
+     * css, js, fonts는 static 폴더에서 파일을 탐색하여 반환합니다. (content header를 text/css로 변경해서 보냅니다.) 나머지(html
+     * 파일)는 templates 폴더에서 탐색합니다.
+     *
+     * @param view
+     * @return
+     * @throws IOException
+     */
+    private ContentsType mapTypeByIndentifier(String view) {
+        //Static 파일 경로에서 탐색
+        for (ContentsType contentsType : ContentsType.values()) {
+            if (view.matches(contentsType.getIdentifier())) {
+                return contentsType;
+            }
+        }
+        throw new IllegalArgumentException("Match되는 Contents-Type이 존재하지 않습니다.");
+    }
+
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -45,10 +45,8 @@ public class RequestHandler implements Runnable {
                 logger.debug("header : {}", requestHeader);
             }
 
-            UrlMapper urlMapper = new UrlMapper(new UserController());
-
             String viewName = urlMapper.requestMapping(httpRequest);
-            byte[] responseMessage = viewResolver.mapView(out, viewName);
+            byte[] responseMessage = viewResolver.mapView(viewName);
 
             DataOutputStream dos = new DataOutputStream(out);
             response(dos, responseMessage);
@@ -57,6 +55,11 @@ public class RequestHandler implements Runnable {
         }
     }
 
+    /**
+     * Response 메시지를 전송합니다.
+     * @param dos
+     * @param body
+     */
     private void response(DataOutputStream dos, byte[] body) {
         try {
             dos.write(body, 0, body.length);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,38 +1,31 @@
 package webserver;
 
-import static response.ContentsType.*;
-
 import controller.UrlMapper;
+import controller.UserController;
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.nio.file.Files;
-import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import controller.UserController;
-import response.ContentsType;
-import response.HttpHeaders;
 import request.HttpRequest;
-import response.HttpResponse;
-import response.Status;
+import view.ViewResolver;
 
 public class RequestHandler implements Runnable {
 
-    private UserController userController = new UserController();
+    private UrlMapper urlMapper;
+    private ViewResolver viewResolver;
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
     private Socket connection;
 
-    public RequestHandler(Socket connectionSocket) {
-        this.connection = connectionSocket;
+    public RequestHandler(UrlMapper urlMapper, ViewResolver viewResolver, Socket connection) {
+        this.urlMapper = urlMapper;
+        this.connection = connection;
+        this.viewResolver = viewResolver;
     }
 
     public void run() {
@@ -54,90 +47,17 @@ public class RequestHandler implements Runnable {
 
             UrlMapper urlMapper = new UrlMapper(new UserController());
 
-            String view = urlMapper.requestMapping(httpRequest);
+            String viewName = urlMapper.requestMapping(httpRequest);
+            byte[] responseMessage = viewResolver.mapView(out, viewName);
 
-            mapView(out, view);
+            DataOutputStream dos = new DataOutputStream(out);
+            response(dos, responseMessage);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
 
-    /**
-     * View의 위치에 있는 파일을 찾아 HTTP 응답으로 보냅니다.
-     *
-     * @param out
-     * @param view
-     * @throws IOException
-     */
-    private void mapView(OutputStream out, String view) throws IOException {
-        DataOutputStream dos = new DataOutputStream(out);
-
-        //Redirect 키워드가 있는 경우 redirect 헤더로 작성
-        if (view.startsWith("redirect:")) {
-            String redirectView = view.replace("redirect:", "");
-            response302Header(dos, redirectView);
-            return;
-        }
-
-        //그 외의 경우 200 OK 응답을 반환
-        byte[] body = mapFilesByType(view, dos);
-        responseBody(dos, body);
-    }
-
-    /**
-     * css, js, fonts는 static 폴더에서 파일을 탐색하여 반환합니다. (content header를 text/css로 변경해서 보냅니다.) 나머지(html
-     * 파일)는 templates 폴더에서 탐색합니다.
-     *
-     * @param view
-     * @param dos
-     * @return
-     * @throws IOException
-     */
-    private byte[] mapFilesByType(String view, DataOutputStream dos) throws IOException {
-        //Static 파일 경로에서 탐색
-        for (ContentsType contentsType : ContentsType.values()) {
-            byte[] body = writeResponse(view, contentsType, dos);
-            if (body != null) {
-                return body;
-            }
-        }
-        return null;
-    }
-
-    private byte[] writeResponse(String view, ContentsType type, DataOutputStream dos)
-        throws IOException {
-        if (view.startsWith(type.getIdentifier())) {
-            byte[] body = Files.readAllBytes(new File(type.getLocatedPath() + view).toPath());
-            response200Header(dos, body.length, Status.OK, type.getContentType());
-            return body;
-        }
-        return null;
-    }
-
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, Status status,
-        String contentType) {
-        HttpResponse httpResponse = new HttpResponse("HTTP/1.1", status,
-            new HttpHeaders(Map.of("Content-Type", contentType, "Content-Length",
-                String.valueOf(lengthOfBodyContent))));
-        writeHeaderBytes(dos, httpResponse);
-    }
-
-    private void response302Header(DataOutputStream dos, String redirectView) {
-
-        HttpResponse httpResponse = new HttpResponse("HTTP/1.1", Status.FOUND,
-            new HttpHeaders(Map.of("Location", redirectView)));
-        writeHeaderBytes(dos, httpResponse);
-    }
-
-    private static void writeHeaderBytes(DataOutputStream dos, HttpResponse httpResponse) {
-        try {
-            dos.writeBytes(httpResponse.toString());
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void responseBody(DataOutputStream dos, byte[] body) {
+    private void response(DataOutputStream dos, byte[] body) {
         try {
             dos.write(body, 0, body.length);
             dos.flush();

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,6 +2,7 @@ package webserver;
 
 import static response.ContentsType.*;
 
+import controller.UrlMapper;
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -17,11 +18,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import controller.UserController;
+import response.ContentsType;
 import response.HttpHeaders;
 import request.HttpRequest;
 import response.HttpResponse;
+import response.Status;
 
 public class RequestHandler implements Runnable {
+
     private UserController userController = new UserController();
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
@@ -32,8 +36,9 @@ public class RequestHandler implements Runnable {
     }
 
     public void run() {
-        logger.debug("New Client Connect! Connected IP : {}, Port : {}", connection.getInetAddress(),
-                connection.getPort());
+        logger.debug("New Client Connect! Connected IP : {}, Port : {}",
+            connection.getInetAddress(),
+            connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
@@ -47,7 +52,9 @@ public class RequestHandler implements Runnable {
                 logger.debug("header : {}", requestHeader);
             }
 
-            String view = userController.requestMapping(httpRequest);
+            UrlMapper urlMapper = new UrlMapper(new UserController());
+
+            String view = urlMapper.requestMapping(httpRequest);
 
             mapView(out, view);
         } catch (IOException e) {
@@ -57,6 +64,7 @@ public class RequestHandler implements Runnable {
 
     /**
      * View의 위치에 있는 파일을 찾아 HTTP 응답으로 보냅니다.
+     *
      * @param out
      * @param view
      * @throws IOException
@@ -66,55 +74,63 @@ public class RequestHandler implements Runnable {
 
         //Redirect 키워드가 있는 경우 redirect 헤더로 작성
         if (view.startsWith("redirect:")) {
-            response302Header(dos, view);
+            String redirectView = view.replace("redirect:", "");
+            response302Header(dos, redirectView);
             return;
         }
 
         //그 외의 경우 200 OK 응답을 반환
-        byte[] body = mapStaticOrTemplateFiles(view, dos);
+        byte[] body = mapFilesByType(view, dos);
         responseBody(dos, body);
     }
 
     /**
-     * css, js, fonts는 static 폴더에서 파일을 탐색하여 반환합니다. (content header를 text/css로 변경해서 보냅니다.)
-     * 나머지(html 파일)는 templates 폴더에서 탐색합니다.
+     * css, js, fonts는 static 폴더에서 파일을 탐색하여 반환합니다. (content header를 text/css로 변경해서 보냅니다.) 나머지(html
+     * 파일)는 templates 폴더에서 탐색합니다.
+     *
      * @param view
      * @param dos
      * @return
      * @throws IOException
      */
-    private byte[] mapStaticOrTemplateFiles(String view, DataOutputStream dos) throws IOException {
+    private byte[] mapFilesByType(String view, DataOutputStream dos) throws IOException {
         //Static 파일 경로에서 탐색
-        if (view.startsWith("/css") || view.startsWith("/js") || view.startsWith("/fonts")) {
-            byte[] body = Files.readAllBytes(new File("src/main/resources/static" + view).toPath());
-            response200Header(dos, body.length, "200", "OK", CSS.getContentType());
+        for (ContentsType contentsType : ContentsType.values()) {
+            byte[] body = writeResponse(view, contentsType, dos);
+            if (body != null) {
+                return body;
+            }
+        }
+        return null;
+    }
+
+    private byte[] writeResponse(String view, ContentsType type, DataOutputStream dos)
+        throws IOException {
+        if (view.startsWith(type.getIdentifier())) {
+            byte[] body = Files.readAllBytes(new File(type.getLocatedPath() + view).toPath());
+            response200Header(dos, body.length, Status.OK, type.getContentType());
             return body;
         }
-        //나머지는 Template 파일에서 탐색
-        byte[] body = Files.readAllBytes(new File("src/main/resources/templates" + view).toPath());
-        response200Header(dos, body.length, "200", "OK", HTML.getContentType());
-        return body;
+        return null;
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String statusCode,
-            String statusMessage, String contentType) {
-        try {
-            //헤더 작성
-            HttpResponse httpResponse = new HttpResponse("HTTP/1.1", statusCode, statusMessage,
-                    new HttpHeaders(Map.of("Content-Type", contentType, "Content-Length",
-                            String.valueOf(lengthOfBodyContent))));
-
-            dos.writeBytes(httpResponse.toString());
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, Status status,
+        String contentType) {
+        HttpResponse httpResponse = new HttpResponse("HTTP/1.1", status,
+            new HttpHeaders(Map.of("Content-Type", contentType, "Content-Length",
+                String.valueOf(lengthOfBodyContent))));
+        writeHeaderBytes(dos, httpResponse);
     }
 
-    private void response302Header(DataOutputStream dos, String view) {
+    private void response302Header(DataOutputStream dos, String redirectView) {
+
+        HttpResponse httpResponse = new HttpResponse("HTTP/1.1", Status.FOUND,
+            new HttpHeaders(Map.of("Location", redirectView)));
+        writeHeaderBytes(dos, httpResponse);
+    }
+
+    private static void writeHeaderBytes(DataOutputStream dos, HttpResponse httpResponse) {
         try {
-            //헤더 작성
-            HttpResponse httpResponse = new HttpResponse("HTTP/1.1", "302", "Found",
-                    new HttpHeaders(Map.of("Location", view.split("redirect:")[1])));
             dos.writeBytes(httpResponse.toString());
         } catch (IOException e) {
             logger.error(e.getMessage());

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -1,5 +1,7 @@
 package webserver;
 
+import controller.UrlMapper;
+import controller.UserController;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
@@ -8,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import util.SocketStatusChecker;
+import view.ViewResolver;
 
 public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
@@ -25,9 +28,15 @@ public class WebServer {
             logger.info("Web Application Server started {} port.", port);
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
+
+            //객체 생성 후 주입
+            UserController userController = new UserController();
+            UrlMapper urlMapper = new UrlMapper(userController);
+            ViewResolver viewResolver = new ViewResolver();
+
             while ((connection = listenSocket.accept()) != null) {
                 connection.setSoTimeout(5000);
-                Thread thread = new Thread(new RequestHandler(connection));
+                Thread thread = new Thread(new RequestHandler(urlMapper, viewResolver, connection));
                 thread.start();
                 SocketStatusChecker.ping(connection, logger);
             }


### PR DESCRIPTION
## 구현 내용
- 지적해주신대로 UserController의 책임이 많아져 Url 매핑을 담당하는 UrlMapper 객체를 만들고, UserController는 유저와 관련된 요청만 처리하도록 구현했습니다.
- ContentsType 타입을 좀더 확장시켜 content-type 헤더의 내용, 파일 저장 위치, 파일 확장자(식별자)를 같이 관리하도록 리팩터링했습니다.
- View도 객체로 만들어서 httpResponse 객체와 viewName, contentsType을 필드 변수로 가지도록 설계했습니다.
- View를 매핑하는 역할을 ViewResolver 객체에서 처리해주도록 변경했습니다.

## 고민한 점
- RequestHandler는 요청마다 객체가 있는게 좋을 것 같아 객체를 생성하게하였고, 나머지 Controller나 UrlMapper 등은 하나의 객체만 생성해서 WebServer에서 주입해주는 방식으로 구현했습니다. 
- 스프링처럼 의존관계를 깔끔하게 주입시키고 싶은데 쉽지 않은 것 같습니다.
- Hyun처럼 정규표현식을 이용해보려했는데 정규표현식이 내포하는 로직이 많아질수록 가독성이 굉장히 안좋아지는 느낌을 받아 포기했습니다. 어느정도까지 활용해야 적절한지 고민됩니다.
