### PR TITLE
[dewey] step-4 : 3단계 피드백 반영, post로 회원가입 구현,

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # 웹서버 1
 > ✏️HTTP 학습하여 웹 서버 구현   
+> ✏️클라이언트에서 전달받은 데이터를 학습하고 
 > ✏️자바의 멀티스레드 프로그래밍 학습   
 > ✏️MIME 타입에 대해 이해하고 이를 적용
+> ✏️HTTP redirection 기능을 적용
 
 ## [매일 TODO 기록](https://github.com/jaea-kim/be-java-was/wiki/TODO)
 
@@ -27,6 +29,14 @@
 * HTTP Response + MIME 타입 학습
 * Stylesheet 파일을 지원하도록 구현 -> 응답 헤더의 Content-Type 이용
   * 요청 헤더의 Accept를 활용 
+
+### 4단계 
+* 3단계 피드백 반영
+  * `Content-Type` enum으로 변경 후 accept와 확장자를 
+* post 메소드 학습
+  * form 데이터를 어떻게 전달하는지 
+  * 사용되는 중요한 헤더가 뭔지 확인
+* post로 변경 시 request 어떻게 오는지 확인
 
 ## 프로젝트 정보 
 

--- a/src/main/java/user/UserController.java
+++ b/src/main/java/user/UserController.java
@@ -23,6 +23,6 @@ public class UserController {
         User user = new User(params.get("userId"), params.get("password"), params.get("name"), params.get("email"));
         logger.debug("user : {}" , user.toString());
 
-        return "/index.html";
+        return "redirect:/index.html";
     }
 }

--- a/src/main/java/webserver/ContentType.java
+++ b/src/main/java/webserver/ContentType.java
@@ -1,0 +1,44 @@
+package webserver;
+
+import java.util.Arrays;
+
+public enum ContentType {
+    JS("application/javascript", ".js", "/static"),
+    CSS("text/css;charset=utf-8", ".css", "/static"),
+    PNG("image/png", ".png", "/static"),
+    ICO("image/avif", ".ico", "/static"),
+    HTML("text/html;charset=utf-8", ".html", "/templates"),
+    FONT("font/woff", ".woff", "/static");
+
+    private String mimeType;
+    private String extension;
+    private String path;
+    private final String RESOURCES_PATH = "src/main/resources";
+
+    ContentType(String mimeType, String extension, String path) {
+        this.mimeType = mimeType;
+        this.extension = extension;
+        this.path = path;
+    }
+
+    public static ContentType of(String requestPath, String accept) {
+        //accept에 모든 mime 타입을 허용하면 파일의 확장자로 결정
+        if (accept.contains("*")) {
+            return Arrays.stream(values())
+                    .filter(contentType -> requestPath.endsWith(contentType.extension))
+                    .findAny().orElse(HTML);
+        }
+        //기본적으로 accept가 content-type이 됨
+        return Arrays.stream(values())
+                .filter(contentType -> contentType.mimeType.contains(accept))
+                .findAny().orElse(HTML);
+    }
+
+    public String getDirectoryPath() {
+        return RESOURCES_PATH + path;
+    }
+
+    public String getMimeTypeString() {
+        return mimeType;
+    }
+}

--- a/src/main/java/webserver/Request.java
+++ b/src/main/java/webserver/Request.java
@@ -15,6 +15,7 @@ public class Request {
     private static final Logger logger = LoggerFactory.getLogger(Request.class);
     private RequestLine requestLine;
     private Map<String, String> header;
+    private String body;
 
     public Request(InputStream in) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(in));
@@ -24,6 +25,13 @@ public class Request {
         String headerString;
         while (!((headerString = br.readLine()).equals(""))) {
             initHeader(headerString);
+        }
+
+        if (header.containsKey("Content-Length")) {
+            int contentLength = Integer.parseInt(header.get("Content-Length").trim());
+            char[] bodyB = new char[contentLength];
+            int length = br.read(bodyB);
+            body = String.valueOf(bodyB);
         }
     }
 
@@ -50,5 +58,9 @@ public class Request {
 
     public String getAccept() {
         return header.get("Accept").split(",")[0];
+    }
+
+    public String getBody() {
+        return body;
     }
 }

--- a/src/main/java/webserver/Request.java
+++ b/src/main/java/webserver/Request.java
@@ -57,7 +57,7 @@ public class Request {
     }
 
     public String getAccept() {
-        return header.get("Accept").split(",")[0];
+        return header.get("Accept").split(",")[0].trim();
     }
 
     public String getBody() {

--- a/src/main/java/webserver/RequestController.java
+++ b/src/main/java/webserver/RequestController.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import util.HttpParser;
 
+import java.io.IOException;
 import java.util.Map;
 
 public class RequestController {
@@ -21,15 +22,24 @@ public class RequestController {
         return RequestControllerHelper.INSTANCE;
     }
 
-    public boolean isRequestGet(Request request) {
-        return request.getMethod().equals("GET");
-    }
-
-    public boolean isRequestStatic(Request request) {
+    public Response process(Request request) throws IOException {
+        //데이터 조회
         if (request.getMethod().equals("GET")) {
-            return !request.isParam();
+            // 동적 데이터 조회
+            if (request.isParam()) {
+                //Todo: 나중에 동적 데이터 조회 필요하면 만들자, 현재는 없는 요청이라서 404 에러페이지 보내기
+                return new Response(StatusCode.NOT_FOUND, "/error.html", request.getAccept());
+            } else { //정적 데이터 조회
+                logger.debug("request static data : {}", request.getPath());
+                return new Response(StatusCode.OK, request.getPath(), request.getAccept());
+            }
+        } else {
+            //데이터 전송 상황
+            logger.debug("request data : {}", request.getPath());
+            String url = getMapping(request);
+            logger.debug("new mapping url : {}", url);
+            return new Response(StatusCode.FOUND, url, request.getAccept());
         }
-        return false;
     }
 
     public String getMapping(Request request) {

--- a/src/main/java/webserver/RequestController.java
+++ b/src/main/java/webserver/RequestController.java
@@ -21,7 +21,11 @@ public class RequestController {
         return RequestControllerHelper.INSTANCE;
     }
 
-    public boolean isMappingView(Request request) {
+    public boolean isRequestGet(Request request) {
+        return request.getMethod().equals("GET");
+    }
+
+    public boolean isRequestStatic(Request request) {
         if (request.getMethod().equals("GET")) {
             return !request.isParam();
         }
@@ -32,11 +36,12 @@ public class RequestController {
         logger.debug("path : {}", request.getPath());
         if (request.getPath().startsWith("/user/create")) {
             UserController userController = UserController.getUserController();
-            Map<String, String> params = HttpParser.getParam(request.getQueryString());
+
+            Map<String, String> params = HttpParser.getParam(request.getBody());
             String url = userController.join(params);
 
             return url;
         }
-        return "/";
+        return "/error.html";
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -26,12 +26,18 @@ public class RequestHandler implements Runnable {
             DataOutputStream dos = new DataOutputStream(out);
             RequestController requestController = RequestController.getRequestController();
 
-            //정적 데이터 조회
-            if (requestController.isMappingView(request)) {
-                logger.debug("request static data : {}", request.getPath());
-                response = new Response(200, request.getPath(), request.getAccept());
-            } else {
-                //동적 데이터 조회 및 데이터 전송 상황
+            //데이터 조회
+            if (requestController.isRequestGet(request)) {
+                // 정적 데이터 조회
+                if (requestController.isRequestStatic(request)) {
+                    logger.debug("request static data : {}", request.getPath());
+                    response = new Response(200, request.getPath(), request.getAccept());
+                } else {
+                    //Todo: 나중에 동적 데이터 조회 필요하면 만들자, 현재는 없는 요청이라서 404 에러페이지 보내기
+                    response = new Response(404, "/error.html", request.getAccept());
+                }
+            }
+             else {//데이터 전송 상황
                 logger.debug("request data : {}", request.getPath());
                 String url = requestController.getMapping(request);
                 logger.debug("new mapping url : {}", url);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -31,17 +31,17 @@ public class RequestHandler implements Runnable {
                 // 정적 데이터 조회
                 if (requestController.isRequestStatic(request)) {
                     logger.debug("request static data : {}", request.getPath());
-                    response = new Response(200, request.getPath(), request.getAccept());
+                    response = new Response(StatusCode.OK, request.getPath(), request.getAccept());
                 } else {
                     //Todo: 나중에 동적 데이터 조회 필요하면 만들자, 현재는 없는 요청이라서 404 에러페이지 보내기
-                    response = new Response(404, "/error.html", request.getAccept());
+                    response = new Response(StatusCode.NOT_FOUND, "/error.html", request.getAccept());
                 }
-            }
-             else {//데이터 전송 상황
+            } else {
+                 //데이터 전송 상황
                 logger.debug("request data : {}", request.getPath());
                 String url = requestController.getMapping(request);
                 logger.debug("new mapping url : {}", url);
-                response = new Response(302, url, request.getAccept());
+                response = new Response(StatusCode.FOUND, url, request.getAccept());
             }
 
             sendResponse(dos, response);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -26,24 +26,7 @@ public class RequestHandler implements Runnable {
             DataOutputStream dos = new DataOutputStream(out);
             RequestController requestController = RequestController.getRequestController();
 
-            //데이터 조회
-            if (requestController.isRequestGet(request)) {
-                // 정적 데이터 조회
-                if (requestController.isRequestStatic(request)) {
-                    logger.debug("request static data : {}", request.getPath());
-                    response = new Response(StatusCode.OK, request.getPath(), request.getAccept());
-                } else {
-                    //Todo: 나중에 동적 데이터 조회 필요하면 만들자, 현재는 없는 요청이라서 404 에러페이지 보내기
-                    response = new Response(StatusCode.NOT_FOUND, "/error.html", request.getAccept());
-                }
-            } else {
-                 //데이터 전송 상황
-                logger.debug("request data : {}", request.getPath());
-                String url = requestController.getMapping(request);
-                logger.debug("new mapping url : {}", url);
-                response = new Response(StatusCode.FOUND, url, request.getAccept());
-            }
-
+            response = requestController.process(request);
             sendResponse(dos, response);
         } catch (IOException e) {
             logger.error(e.getMessage());

--- a/src/main/java/webserver/Response.java
+++ b/src/main/java/webserver/Response.java
@@ -9,8 +9,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class Response {
-    private final String templatesResourcePath = "src/main/resources/templates";
-    private final String staticResourcePath = "src/main/resources/static";
     private String statusLine;
     private Map<String, String> headers = new HashMap<>();
     private byte[] body = {};
@@ -26,8 +24,9 @@ public class Response {
             String path = requestPath.replace("redirect:", "");
             setHeader("Location", path);
         } else {
-            body = setMessageBody(accept, requestPath);
-            setHeader("Content-Type", accept + ";charset=utf-8");
+            ContentType contentType = ContentType.of(requestPath, accept);
+            setHeader("Content-Type", contentType.getMimeTypeString());
+            body = setMessageBody(contentType.getDirectoryPath(), requestPath);
             setHeader("Content-Length", String.valueOf(body.length));
 
         }
@@ -37,12 +36,8 @@ public class Response {
         headers.put(headerName, value);
     }
 
-    private byte[] setMessageBody(String accept, String requestPath) throws IOException {
-        if (accept.contains("html")) {
-            return Files.readAllBytes(new File(templatesResourcePath + requestPath).toPath());
-        } else {
-            return Files.readAllBytes(new File(staticResourcePath + requestPath).toPath());
-        }
+    private byte[] setMessageBody(String directoryPath, String requestPath) throws IOException {
+        return Files.readAllBytes(new File(directoryPath + requestPath).toPath());
     }
 
     public byte[] getMessageBody() {

--- a/src/main/java/webserver/Response.java
+++ b/src/main/java/webserver/Response.java
@@ -23,6 +23,10 @@ public class Response {
         } else if (code == 302) {
             statusLine = StatusCode.FOUND.getStatusLine();
             headers = set302Header(requestPath);
+        } else if (code == 404) {
+            statusLine = StatusCode.NOT_FOUND.getStatusLine();
+            body = setMessageBody(accept, requestPath);
+            headers = set200Header(accept, body.length);
         }
     }
 
@@ -30,7 +34,14 @@ public class Response {
         return "Content-Type:" + accept + ";charset=utf-8\r\nContent-Length: " + bodyLength + "\r\n";
     }
 
-    private String set302Header(String url) {
+    private String set302Header(String requestPath) {
+        String url;
+        if (requestPath.startsWith("redirect:")) {
+            int p = requestPath.indexOf(":");
+            url = requestPath.substring(p + 1);
+        } else {
+            url = "/index.html";
+        }
         return "Location: " + url;
     }
 

--- a/src/main/java/webserver/StatusCode.java
+++ b/src/main/java/webserver/StatusCode.java
@@ -1,7 +1,6 @@
 package webserver;
 
 import java.util.Arrays;
-import java.util.Map;
 
 public enum StatusCode {
     OK(200, "200 OK"),

--- a/src/main/java/webserver/StatusCode.java
+++ b/src/main/java/webserver/StatusCode.java
@@ -5,7 +5,8 @@ import java.util.Map;
 
 public enum StatusCode {
     OK(200, "200 OK"),
-    FOUND(302, "302 FOUND");
+    FOUND(302, "302 FOUND"),
+    NOT_FOUND(404, "404 NOT FOUND");
 
     private int code;
     private String statusCode;

--- a/src/main/resources/templates/user/form.html
+++ b/src/main/resources/templates/user/form.html
@@ -75,7 +75,7 @@
 <div class="container" id="main">
    <div class="col-md-6 col-md-offset-3">
       <div class="panel panel-default content-main">
-          <form name="question" method="get" action="/user/create">
+          <form name="question" method="post" action="/user/create">
               <div class="form-group">
                   <label for="userId">사용자 아이디</label>
                   <input class="form-control" id="userId" name="userId" placeholder="user ID">


### PR DESCRIPTION
## 구현 내용
* 3단계 피드백 반영
> **`ContentType` enum으로 구현**
> * Content Type 지정 방식
> 요청 Accept 헤더에 MIME 타입이 명시되어 있을 경우, 서버는 해당 MIME 타입을 우선적으로 고려한다고 하여 accept 가 모든 확장자를 허용하면 확장자를 기준으로 지정 아닐 경우 accept의 MIME 타입으로 지정   

* post로 회원가입 구현 
> 요청 헤더에 `Content-Length`가 존재하면 요청 body가 있다고 판단하여 body내용을 Content-Length 만큼 저장 
> `user/create` 로 시작하는 url이 요청 오면 요청 바디를 읽어 파싱하여 userController.join으로 넘겨줌 

## 고민 사항
1. 클라이언트에서 서버로 요청이 왔을 때 상황처리를 어디서 해줘야할까? 
-> 기존에는 `requestHandler`에서 처리하였는데 핸들러의 역할이 너무 크다는 느낌을 받아 `requestController`로 변경 
-> `requestController`에서 처리 후 response를 반환 
2. 응답코드마다 필수로 존재하는 헤더가 다른데 이걸 어디서 어떻게 처리해줘야 좋을까? 
-> 서버에서 클라이언트에 응답하는 방식은 현재는 forward, redirect 두가지 방식만 사용한다. Response 에서 path가 redirect로 시작하면 redirect 방식은 아니면 forward 방식을 사용하도록 했다.
3. 응답을 보내는 것까지 response에서 하는게 좋을까? 
-> 현재는 `RequestHandler`에서 응답을 send하고 있다. 그러기 우해서는 response에서 header와 body를 읽어오게 되는데 굳이 읽어와야할까 하는 생각이 있다. response에게 send하라고 요청을 보내면 response 객체가 자기 응답을 send하는 것이 더 명확하지 않을까? 싶은 생긱이 든다. 