### PR TITLE
[poro] step-6 리팩토링, 템플릿 엔진 로직 개선, 세션,로깅 인터셉터 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation 'com.google.guava:guava:29.0-jre'
     implementation 'ch.qos.logback:logback-classic:1.2.3'
     implementation 'com.github.jknack:handlebars:4.2.0'
+    implementation group: 'cglib', name: 'cglib', version: '3.3.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'

--- a/src/main/java/controller/FrontController.java
+++ b/src/main/java/controller/FrontController.java
@@ -4,30 +4,18 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 import mapper.HandlerMapper;
+import mapper.MappingInfoRepository;
 import request.HttpRequest;
 import response.HttpResponse;
 
 public class FrontController {
-
-    private Map<String, Controller> handlerControllerMap;
-
-    public FrontController() {
-        handlerControllerMap = HandlerMapper.doMapController();
-        HandlerMapper.doMapMethods(handlerControllerMap);
-    }
 
     /**
      * 처리할 Controller를 조회해서 리턴합니다.
      * @param httpRequest
      * @return
      */
-    public Controller getHandler(HttpRequest httpRequest) {
-        return handlerControllerMap.get(httpRequest.getUrl());
-    }
 
-    public boolean hasMapping(HttpRequest httpRequest) {
-        return handlerControllerMap.containsKey(httpRequest.getUrl());
-    }
 
     /**
      * 들어온 요청을 적합한 Controller에게 위임한다.
@@ -35,11 +23,11 @@ public class FrontController {
      * @return
      */
     public String dispatch(HttpRequest httpRequest, HttpResponse httpResponse) {
-        if (!hasMapping(httpRequest)) {
+        if (!MappingInfoRepository.hasMapping(httpRequest)) {
             return httpRequest.getUrl();
         }
 
-        Controller controller = getHandler(httpRequest);
+        Controller controller = MappingInfoRepository.getHandler(httpRequest);
         String viewName;
         try {
             viewName = controller.process(httpRequest, httpResponse);

--- a/src/main/java/controller/HomeController.java
+++ b/src/main/java/controller/HomeController.java
@@ -1,17 +1,9 @@
 package controller;
 
-import java.util.Optional;
-
-import annotation.ExceptionHandler;
 import annotation.MethodType;
 import annotation.RequestMapping;
-import db.Database;
-import exception.UserInfoException;
-import model.User;
 import request.HttpRequest;
-import request.HttpRequestUtils;
 import response.HttpResponse;
-import session.SessionDb;
 
 @RequestMapping(url = "/")
 public class HomeController extends Controller {
@@ -25,29 +17,6 @@ public class HomeController extends Controller {
      */
     @MethodType(value = "GET")
     public String home(HttpRequest httpRequest, HttpResponse httpResponse) {
-        Optional<String> sessionId = httpRequest.getSessionId();
-        //Home 아이콘에 비회원 Or 회원 ID를 표시해주는 기능
-        httpResponse.setModelAttribute("loginedUserId", "비회원");
-        if (!sessionId.isEmpty()) {
-            String parsedSessionId = HttpRequestUtils.parseSessionId(sessionId.get());
-
-            User loginedUser = SessionDb.getUserBySessionId(parsedSessionId);
-
-            //유효한 세션이 아닌 경우 쿠키를 초기화
-            if (loginedUser == null) {
-                //유효 세션이 아니면 요청에 보내고 있는 쿠키 무효화하기
-                httpResponse.addHeader("Set-Cookie", String.format("sid=%s; Path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT;", parsedSessionId));
-                throw new UserInfoException("세션이 만료되었습니다.");
-            }
-
-            httpResponse.setModelAttribute("loginedUserId", loginedUser.getUserId());
-        }
-
-        return "/index.html";
-    }
-
-    @ExceptionHandler(exception = "UserInfoException.class")
-    public String invalidSession(HttpRequest httpRequest, HttpResponse httpResponse) {
         return "/index.html";
     }
 }

--- a/src/main/java/interceptor/Interceptor.java
+++ b/src/main/java/interceptor/Interceptor.java
@@ -1,0 +1,71 @@
+package interceptor;
+
+import exception.UserInfoException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import model.User;
+import net.sf.cglib.proxy.MethodInterceptor;
+import net.sf.cglib.proxy.MethodProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import request.HttpRequest;
+import request.HttpRequestUtils;
+import response.HttpResponse;
+import session.SessionDb;
+
+public class Interceptor implements MethodInterceptor {
+
+    private static final Logger logger = LoggerFactory.getLogger(Interceptor.class);
+
+    @Override
+    public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy)
+        throws Throwable {
+        if (method.getName().contains("process")) {
+            try {
+                prehandle(obj, method, args);
+            } catch (UserInfoException e) {
+                logger.debug("현재 세션이 유효하지 않아 초기화됩니다.");
+                return "redirect:/";
+            }
+            Object object = proxy.invokeSuper(obj, args);
+            posthandle(obj, method);
+            return object;
+        }
+
+        return proxy.invokeSuper(obj, args);
+    }
+
+    private void prehandle(Object obj, Method method, Object[] args) {
+        logger.debug("실행 전 - 현재 실행 클래스 : {}, 메소드 : {}", obj.getClass().getSuperclass().toString(), method.getName() );
+        checkCurrentSession((HttpRequest) args[0], (HttpResponse) args[1]);
+    }
+
+    private void posthandle(Object obj, Method method) {
+        logger.debug("실행 후 - 현재 실행 클래스 : {}, 메소드 : {}", obj.getClass().getSuperclass().toString(), method.getName() );
+    }
+    /**
+     * 모든 컨트롤러가 실행될 때 현재 쿠키를 세션에서 확인하고 유효하지 않으면 무효화합니다.
+     * @param httpRequest
+     * @param httpResponse
+     * @throws UserInfoException
+     */
+    private void checkCurrentSession(HttpRequest httpRequest, HttpResponse httpResponse) throws UserInfoException {
+        Optional<String> sessionId = httpRequest.getSessionId();
+        //Home 아이콘에 비회원 Or 회원 ID를 표시해주는 기능
+        httpResponse.setModelAttribute("loginedUserId", "비회원");
+        if (!sessionId.isEmpty()) {
+            String parsedSessionId = HttpRequestUtils.parseSessionId(sessionId.get());
+
+            User loginedUser = SessionDb.getUserBySessionId(parsedSessionId);
+
+            //유효한 세션이 아닌 경우 쿠키를 초기화
+            if (loginedUser == null) {
+                //유효 세션이 아니면 요청에 보내고 있는 쿠키 무효화하기
+                httpResponse.addHeader("Set-Cookie", String.format("sid=%s; Path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT;", parsedSessionId));
+                throw new UserInfoException("세션이 만료되었습니다.");
+            }
+
+            httpResponse.setModelAttribute("loginedUserId", loginedUser.getUserId());
+        }
+    }
+}

--- a/src/main/java/mapper/MappingInfoRepository.java
+++ b/src/main/java/mapper/MappingInfoRepository.java
@@ -1,0 +1,54 @@
+package mapper;
+
+import annotation.MethodType;
+import controller.Controller;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import request.HttpRequest;
+
+public class MappingInfoRepository {
+
+    private static Map<String, Class<?>> exceptionMap = new HashMap<>();
+    private static Map<String, Controller> controllerMap = new HashMap<>();
+    private final static Map<String, MethodMap> handlerMethodMap = new HashMap<>();
+
+    public static void initMapping() {
+        controllerMap = HandlerMapper.doMapController();
+        HandlerMapper.doMapMethods(controllerMap);
+    }
+
+    public static void initMethodMapping(Controller controller) {
+        MethodMap methodMap = new MethodMap();
+        //어노테이션 메소드 목록을 Reflection으로 불러와서 map에 추가
+        //Proxy 타겟의 메소드를 불러와야해서 getSuperclass 추가
+        for (Method method : controller.getClass().getSuperclass().getDeclaredMethods()) {
+            Annotation annotation = method.getDeclaredAnnotation(MethodType.class);
+            if (annotation instanceof MethodType) {
+                MethodType methodType = (MethodType)annotation;
+                methodMap.put(methodType.value(), method);
+            }
+        }
+        exceptionMap = ExceptionMapper.doMapException();
+        //Controller 이름 - Controller의 Method 리스트 매핑
+        handlerMethodMap.put(controller.getClass().getName(), methodMap);
+    }
+
+    public static Method getMappedMethod(String handlerName, String method) {
+        return handlerMethodMap.get(handlerName).get(method);
+    }
+
+    public static Class<?> getException(String exceptionName) {
+        return exceptionMap.get(exceptionName);
+    }
+
+    public static Controller getHandler(HttpRequest httpRequest) {
+        return controllerMap.get(httpRequest.getUrl());
+    }
+
+    public static boolean hasMapping(HttpRequest httpRequest) {
+        return controllerMap.containsKey(httpRequest.getUrl());
+    }
+
+}

--- a/src/main/java/mapper/MethodMap.java
+++ b/src/main/java/mapper/MethodMap.java
@@ -1,0 +1,21 @@
+package mapper;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MethodMap {
+    private Map<String, Method> handlerMethodMap;
+
+    public MethodMap() {
+        handlerMethodMap = new HashMap<>();
+    }
+
+    public void put(String methodName, Method method) {
+        handlerMethodMap.put(methodName, method);
+    }
+
+    public Method get(String methodName) {
+        return handlerMethodMap.get(methodName);
+    }
+}

--- a/src/main/java/model/User.java
+++ b/src/main/java/model/User.java
@@ -1,6 +1,7 @@
 package model;
 
 public class User {
+    private int index;
     private String userId;
     private String password;
     private String name;
@@ -31,6 +32,10 @@ public class User {
 
     public String getEmail() {
         return email;
+    }
+
+    public int getIndex() {
+        return index;
     }
 
     @Override

--- a/src/main/java/response/ContentsType.java
+++ b/src/main/java/response/ContentsType.java
@@ -2,22 +2,19 @@ package response;
 
 public enum ContentsType {
 
-    CSS("text/css;charset=utf-8", "static", ".*\\.css"),
-    JS("application/javascript", "static", ".*\\.js"),
-    FONTS("application/octet-stream", "static", ".*\\.woff$|.*\\.woff2$.*\\.woff3$"),
-    PNG("image/png", "static", ".*\\.png"),
-    ICO("image/avif", "templates", ".*\\.ico"),
-    HTML("text/html;charset=utf-8", "templates", ".*\\.html");
+    CSS("text/css;charset=utf-8", ".*\\.css"),
+    JS("application/javascript", ".*\\.js"),
+    FONTS("application/octet-stream", ".*\\.woff$|.*\\.woff2$.*\\.woff3$"),
+    PNG("image/png", ".*\\.png"),
+    ICO("image/avif", ".*\\.ico"),
+    HTML("text/html;charset=utf-8", ".*\\.html");
 
-    private static final String BASE_DIR = "src/main/resources/";
     private String contentType;
-    private String locatedPath;
     private String identifier;
 
-    ContentsType(String contentType, String locatedPath, String identifier) {
+    ContentsType(String contentType, String identifier) {
         this.contentType = contentType;
         this.identifier = identifier;
-        this.locatedPath = BASE_DIR + locatedPath;
     }
 
     public String getContentType() {
@@ -26,9 +23,5 @@ public enum ContentsType {
 
     public String getIdentifier() {
         return identifier;
-    }
-
-    public String getLocatedPath() {
-        return locatedPath;
     }
 }

--- a/src/main/java/response/HttpResponse.java
+++ b/src/main/java/response/HttpResponse.java
@@ -72,8 +72,6 @@ public class HttpResponse {
         httpHeaders.put("Content-Length", String.valueOf(contentLength));
     }
 
-
-
     public byte[] getResponseLine() {
         String headLine = String.join(" ", httpVersion, status.getStatusCode(), status.getStatusMessage());
         return (headLine + "\r\n" + httpHeaders).getBytes();
@@ -87,9 +85,11 @@ public class HttpResponse {
         outputStream.write(headers);
         if (modelAndView.hasBody()) {
             //템플릿 엔진 기능 추가
-            byte[] body = Files.readAllBytes(new File(modelAndView.getPath()).toPath());
+            byte[] body = Files.readAllBytes(modelAndView.getFile().toPath());
+            if (modelAndView.isDynamicFile()) {
+                body = PoroTouch.render(body, modelAndView);
+            }
 
-            body = PoroTouch.render(body, modelAndView);
             //ContentLength도 같이 바꿔줘야함
             setContentLength(body.length);
             outputStream.write(body);

--- a/src/main/java/response/HttpResponse.java
+++ b/src/main/java/response/HttpResponse.java
@@ -3,9 +3,13 @@ package response;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.List;
 
+import java.util.stream.Collectors;
 import model.User;
 import templateEngine.PoroTouch;
 import view.ModelAndView;
@@ -45,26 +49,12 @@ public class HttpResponse {
         return this;
     }
 
-    public HttpResponse setContentsType(ContentsType contentsType){
+    public HttpResponse setContentsType(ContentsType contentsType) {
         modelAndView.setContentsType(contentsType);
         return this;
     }
 
     public void setModelAttribute(String attributeName, Object attribute) {
-        //TODO : 현재는 유저 리스트만 호환됨
-        if (attribute instanceof List) {
-            List<User> userList = (List<User>)attribute;
-            int index = 0;
-            for (User user : userList) {
-                modelAndView.setModelAttribute("user.userId"+index, user.getUserId());
-                modelAndView.setModelAttribute("user.password"+index, user.getPassword());
-                modelAndView.setModelAttribute("user.name"+index, user.getName());
-                modelAndView.setModelAttribute("user.email"+index, user.getEmail());
-                modelAndView.setModelAttribute("user.index"+index, String.valueOf(index));
-                index++;
-            }
-            modelAndView.setModelAttribute("maxCount", String.valueOf(index));
-        }
         modelAndView.setModelAttribute(attributeName, attribute);
     }
 
@@ -73,7 +63,8 @@ public class HttpResponse {
     }
 
     public byte[] getResponseLine() {
-        String headLine = String.join(" ", httpVersion, status.getStatusCode(), status.getStatusMessage());
+        String headLine = String.join(" ", httpVersion, status.getStatusCode(),
+            status.getStatusMessage());
         return (headLine + "\r\n" + httpHeaders).getBytes();
     }
 

--- a/src/main/java/response/HttpResponse.java
+++ b/src/main/java/response/HttpResponse.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
@@ -63,9 +64,11 @@ public class HttpResponse {
     }
 
     public byte[] getResponseLine() {
+        final String CRLF = "\r\n";
+
         String headLine = String.join(" ", httpVersion, status.getStatusCode(),
             status.getStatusMessage());
-        return (headLine + "\r\n" + httpHeaders).getBytes();
+        return (headLine + CRLF + httpHeaders).getBytes();
     }
 
     public byte[] render() throws IOException {
@@ -78,7 +81,11 @@ public class HttpResponse {
             //템플릿 엔진 기능 추가
             byte[] body = Files.readAllBytes(modelAndView.getFile().toPath());
             if (modelAndView.isDynamicFile()) {
-                body = PoroTouch.render(body, modelAndView);
+                try {
+                    body = PoroTouch.render(body, modelAndView).getBytes(StandardCharsets.UTF_8);
+                } catch (InvocationTargetException | IllegalAccessException e){
+                    e.printStackTrace();
+                }
             }
 
             //ContentLength도 같이 바꿔줘야함
@@ -88,6 +95,4 @@ public class HttpResponse {
 
         return outputStream.toByteArray();
     }
-
-
 }

--- a/src/main/java/templateEngine/PoroTouch.java
+++ b/src/main/java/templateEngine/PoroTouch.java
@@ -1,67 +1,68 @@
 package templateEngine;
 
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 
 import view.ModelAndView;
 
 /**
  * PoroTouch 사용법
- *
- * 1. 문법 : ^P$(속성 Key)P^를 HTML에 입력합니다. Model에서 key에 해당하는 Value를 찾아 HTML을 변경해줍니다.
- * 2. 반복 기능 : 반복하고 싶은 구간을 ^Start^와 ^End^로 감쌉니다. 구간 내의 ^P$(속성 Key)P^의 개수만큼 HTML을 추가합니다.
- * 성능..?
+ * <p>
+ * 1. 문법 : ^P$(속성 Key)P^를 HTML에 입력합니다. Model에서 key에 해당하는 Value를 찾아 HTML을 변경해줍니다. 2. 반복 기능 : 반복하고 싶은
+ * 구간을 ^Start^와 ^End^로 감쌉니다. 구간 내의 ^P$(속성 Key)P^의 개수만큼 HTML을 추가합니다. 성능..?
  */
 public class PoroTouch {
 
     public static String OPENING_TAG = "^P";
     public static String CLOSING_TAG = "P^";
-    public static String START_TAG = "^Start^";
-    public static String END_TAG = "^End^";
+    public static String BLOCK_OPENING_TAG = "^#";
+    public static String BLOCK_OPENING_END_TAG = "#^";
+    public static String BLOCK_CLOSING_TAG = "^/";
+    public static String BLOCK_CLOSING_END_TAG = "/^";
 
-    public static byte[] render(byte[] body, ModelAndView modelAndView) throws UnsupportedEncodingException {
-        String bodyString = new String(body);
-
-        StringBuilder sb = new StringBuilder(bodyString);
+    public static byte[] render(byte[] body, ModelAndView modelAndView)
+        throws UnsupportedEncodingException {
+        StringBuilder sb = new StringBuilder(new String(body));
 
         //블록 반복 기능
-        if (sb.toString().contains(START_TAG)) {
-            while (sb.toString().contains(START_TAG)) {
+        if (sb.toString().contains(BLOCK_OPENING_TAG)) {
+            while (sb.toString().contains(BLOCK_OPENING_TAG)) {
+                //블록 반복 구간의 객체 Key를 읽어온다.
+                int startBlockOpeningIdx = sb.indexOf(BLOCK_OPENING_TAG);
+                int startBlockClosingIdx = sb.indexOf(BLOCK_OPENING_END_TAG);
+                String objectAttributeKey = sb.substring(
+                    startBlockOpeningIdx + BLOCK_OPENING_TAG.length(), startBlockClosingIdx).trim();
+
                 //반복 블록 구간을 blockBuilder에 저장
-                int startOfBlockWithTag = sb.indexOf(START_TAG);
-                int startOfBlockWithoutTag = sb.indexOf(START_TAG) + START_TAG.length();
+                int startOfBlockWithoutTag = startBlockClosingIdx + BLOCK_OPENING_END_TAG.length();
 
-                int endOfBlockWithTag = sb.indexOf(END_TAG) + END_TAG.length();
-                int endOfBlockWithoutTag = sb.indexOf(END_TAG);
-
-                if (modelAndView.getModelAttribute("maxCount") == null) {
-                    return sb.replace(startOfBlockWithTag, endOfBlockWithTag, "").toString().getBytes("UTF-8");
-                }
+                int endOfBlockWithTag =
+                    sb.indexOf(BLOCK_CLOSING_END_TAG) + BLOCK_CLOSING_END_TAG.length();
+                int endOfBlockWithoutTag = sb.indexOf(BLOCK_CLOSING_TAG);
 
                 StringBuilder blockBuilder = new StringBuilder();
-                int maxCount = Integer.parseInt((String)modelAndView.getModelAttribute("maxCount"));
-                for (int order = 0; order < maxCount; order++) {
-                    blockBuilder.append(sb.substring(startOfBlockWithoutTag, endOfBlockWithoutTag));
 
-                    while (blockBuilder.toString().contains(OPENING_TAG)) {
-                        int startIndex = blockBuilder.indexOf(OPENING_TAG);
-                        int endIndex = blockBuilder.indexOf(CLOSING_TAG);
-
-                        //Model 속성 이름을 찾는다.
-                        String modelAttributeKey =
-                                blockBuilder.substring(startIndex + OPENING_TAG.length(), endIndex).trim() + order;
-
-                        Object modelAttribute = modelAndView.getModelAttribute(modelAttributeKey);
-                        if (modelAttribute != null) {
-                            blockBuilder.replace(startIndex, endIndex + CLOSING_TAG.length(),
-                                    modelAttribute.toString());
-                        }
+                Object object = modelAndView.getModelAttribute(objectAttributeKey);
+                if (object instanceof List) {
+                    for (Object item : (List) object) {
+                        //TODO : List<List<>>인 경우 오브젝트에 대한 로직을 재귀적으로 수행하도록 구현하면 좋을듯?
+                        blockBuilder.append(
+                            sb.substring(startOfBlockWithoutTag, endOfBlockWithoutTag));
+                        renderBlock(blockBuilder, item);
                     }
+                    sb.replace(startBlockOpeningIdx, endOfBlockWithTag, blockBuilder.toString());
+                } else {
+                    blockBuilder.append(
+                        sb.substring(startOfBlockWithoutTag, endOfBlockWithoutTag));
+
+                    renderTags(modelAndView, blockBuilder);
+                    sb.replace(startBlockOpeningIdx, endOfBlockWithTag, blockBuilder.toString());
                 }
-
-                sb.replace(startOfBlockWithTag, endOfBlockWithTag, blockBuilder.toString());
-
             }
+
             return sb.toString().getBytes("UTF-8");
         }
 
@@ -79,14 +80,54 @@ public class PoroTouch {
             int startIndex = sb.indexOf(OPENING_TAG);
             int endIndex = sb.indexOf(CLOSING_TAG);
             //Model 속성 이름을 찾는다.
-            String modelAttributeKey = sb.substring(startIndex + OPENING_TAG.length(), endIndex).trim();
+            String modelAttributeKey = sb.substring(startIndex + OPENING_TAG.length(), endIndex)
+                .trim();
 
             Object modelAttribute = modelAndView.getModelAttribute(modelAttributeKey);
+
+            //String인 경우 그대로 출력
+
             if (modelAttribute != null) {
-                sb.replace(startIndex, endIndex + CLOSING_TAG.length(), modelAttribute.toString());
-                continue;
+                if (modelAttribute instanceof String) {
+                    sb.replace(startIndex, endIndex + CLOSING_TAG.length(),
+                        modelAttribute.toString());
+                    continue;
+                }
             }
             sb.replace(startIndex, endIndex + CLOSING_TAG.length(), "");
         }
+
+    }
+
+    private static void renderBlock(StringBuilder sb, Object item) {
+        while (sb.toString().contains(OPENING_TAG)) {
+            int startIndex = sb.indexOf(OPENING_TAG);
+            int endIndex = sb.indexOf(CLOSING_TAG);
+            //Model 속성 이름을 찾는다.
+            String fieldKey = sb.substring(startIndex + OPENING_TAG.length(), endIndex).trim();
+
+            if (item != null) {
+                Method getter = Arrays.stream(
+                        item.getClass().getDeclaredMethods())
+                    .filter(method -> method.getName().startsWith("get") && method.getName()
+                        .toLowerCase()
+                        .endsWith(fieldKey.toLowerCase()))
+                    .findFirst().orElseThrow(() -> {
+                        throw new IllegalArgumentException("존재하지 않는 모델입니다.");
+                    });
+                try {
+                    Object object = getter.invoke(item);
+                    sb.replace(startIndex, endIndex + CLOSING_TAG.length(),
+                        String.valueOf(object));
+                    continue;
+                } catch (IllegalAccessException |
+                         InvocationTargetException e) {
+                    throw new IllegalArgumentException();
+                }
+            }
+            sb.replace(startIndex, endIndex + CLOSING_TAG.length(), "");
+        }
+
     }
 }
+

--- a/src/main/java/templateEngine/PoroTouch.java
+++ b/src/main/java/templateEngine/PoroTouch.java
@@ -1,6 +1,5 @@
 package templateEngine;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -11,11 +10,14 @@ import view.ModelAndView;
 /**
  * PoroTouch 사용법
  * <p>
- * 1. 문법 : ^P$(속성 Key)P^를 HTML에 입력합니다. Model에서 key에 해당하는 Value를 찾아 HTML을 변경해줍니다. 2. 반복 기능 : 반복하고 싶은
- * 구간을 ^Start^와 ^End^로 감쌉니다. 구간 내의 ^P$(속성 Key)P^의 개수만큼 HTML을 추가합니다. 성능..?
+ * 1. 문법 : ^P$(속성 Key)P^를 HTML에 입력합니다. Model에서 key에 해당하는 Value를 찾아 HTML을 변경해줍니다.
+ * 2. 반복 기능 : 반복하고 싶은 구간을 ^# $(속성 타입 이름) #^로 감쌉니다. 구간 내에는 ^P$(필드 key)P^로 Getter를 호출 가능.
+ * (List 지원)
  */
 public class PoroTouch {
 
+    public static final String EMPTY = "";
+    public static final String GETTER = "get";
     public static String OPENING_TAG = "^P";
     public static String CLOSING_TAG = "P^";
     public static String BLOCK_OPENING_TAG = "^#";
@@ -23,111 +25,106 @@ public class PoroTouch {
     public static String BLOCK_CLOSING_TAG = "^/";
     public static String BLOCK_CLOSING_END_TAG = "/^";
 
-    public static byte[] render(byte[] body, ModelAndView modelAndView)
-        throws UnsupportedEncodingException {
-        StringBuilder sb = new StringBuilder(new String(body));
+    public static String render(byte[] body, ModelAndView mv)
+        throws InvocationTargetException, IllegalAccessException {
+        StringBuilder builder = new StringBuilder(new String(body));
 
-        //블록 반복 기능
-        if (sb.toString().contains(BLOCK_OPENING_TAG)) {
-            while (sb.toString().contains(BLOCK_OPENING_TAG)) {
-                //블록 반복 구간의 객체 Key를 읽어온다.
-                int startBlockOpeningIdx = sb.indexOf(BLOCK_OPENING_TAG);
-                int startBlockClosingIdx = sb.indexOf(BLOCK_OPENING_END_TAG);
-                String objectAttributeKey = sb.substring(
-                    startBlockOpeningIdx + BLOCK_OPENING_TAG.length(), startBlockClosingIdx).trim();
+        //블록 타입 처리 - Custom 타입 가능
+        while (builder.toString().contains(BLOCK_OPENING_TAG)) {
+            //블록 반복 구간의 객체 Key를 읽어온다.
+            int blockStartOpenTag = builder.indexOf(BLOCK_OPENING_TAG);
+            int blockStartCloseTag = builder.indexOf(BLOCK_OPENING_END_TAG);
+            String blockAttrKey = builder.substring(
+                blockStartOpenTag + BLOCK_OPENING_TAG.length(), blockStartCloseTag).trim();
 
-                //반복 블록 구간을 blockBuilder에 저장
-                int startOfBlockWithoutTag = startBlockClosingIdx + BLOCK_OPENING_END_TAG.length();
+            //반복 블록 구간을 blockBuilder에 저장
+            int blockEndCloseTag =
+                builder.indexOf(BLOCK_CLOSING_END_TAG) + BLOCK_CLOSING_END_TAG.length();
 
-                int endOfBlockWithTag =
-                    sb.indexOf(BLOCK_CLOSING_END_TAG) + BLOCK_CLOSING_END_TAG.length();
-                int endOfBlockWithoutTag = sb.indexOf(BLOCK_CLOSING_TAG);
+            int blockFrom = blockStartCloseTag + BLOCK_OPENING_END_TAG.length();
+            int blockTo = builder.indexOf(BLOCK_CLOSING_TAG);
 
-                StringBuilder blockBuilder = new StringBuilder();
+            StringBuilder blockBuilder = new StringBuilder();
 
-                Object object = modelAndView.getModelAttribute(objectAttributeKey);
-                if (object instanceof List) {
-                    for (Object item : (List) object) {
-                        //TODO : List<List<>>인 경우 오브젝트에 대한 로직을 재귀적으로 수행하도록 구현하면 좋을듯?
-                        blockBuilder.append(
-                            sb.substring(startOfBlockWithoutTag, endOfBlockWithoutTag));
-                        renderBlock(blockBuilder, item);
-                    }
-                    sb.replace(startBlockOpeningIdx, endOfBlockWithTag, blockBuilder.toString());
-                } else {
-                    blockBuilder.append(
-                        sb.substring(startOfBlockWithoutTag, endOfBlockWithoutTag));
+            Object object = mv.getModelAttribute(blockAttrKey);
+            //타입이 리스트인 경우, 리스트 재귀인 경우
+            if (object instanceof List) {
+                renderListRecursively(object, blockBuilder, builder.substring(blockFrom, blockTo));
+                builder.replace(blockStartOpenTag, blockEndCloseTag, blockBuilder.toString());
+            } else {
+                //반복문 안에 다른 attribute가 오더라도 처리 가능
+                blockBuilder.append(builder.substring(blockFrom, blockTo));
 
-                    renderTags(modelAndView, blockBuilder);
-                    sb.replace(startBlockOpeningIdx, endOfBlockWithTag, blockBuilder.toString());
-                }
+                renderStringTags(mv, blockBuilder);
+                builder.replace(blockStartOpenTag, blockEndCloseTag, blockBuilder.toString());
             }
-
-            return sb.toString().getBytes("UTF-8");
         }
 
-        if (sb.toString().contains(OPENING_TAG)) {
-            //기본 태그 처리
-            renderTags(modelAndView, sb);
-            return sb.toString().getBytes("UTF-8");
+        //기본 태그 처리 : String Type만 가능
+        if (builder.toString().contains(OPENING_TAG)) {
+            renderStringTags(mv, builder);
         }
 
-        return body;
+        return builder.toString();
     }
 
-    private static void renderTags(ModelAndView modelAndView, StringBuilder sb) {
+    private static void renderListRecursively(Object object, StringBuilder blockBuilder, String block)
+        throws InvocationTargetException, IllegalAccessException {
+        for (Object item : (List) object) {
+            if (item instanceof List) {
+                renderListRecursively(item, blockBuilder, block);
+                continue ;
+            }
+            blockBuilder.append(block);
+            renderBlockItem(blockBuilder, item);
+        }
+    }
+
+    private static void renderStringTags(ModelAndView modelAndView, StringBuilder sb) {
         while (sb.toString().contains(OPENING_TAG)) {
             int startIndex = sb.indexOf(OPENING_TAG);
             int endIndex = sb.indexOf(CLOSING_TAG);
-            //Model 속성 이름을 찾는다.
+
             String modelAttributeKey = sb.substring(startIndex + OPENING_TAG.length(), endIndex)
                 .trim();
 
             Object modelAttribute = modelAndView.getModelAttribute(modelAttributeKey);
 
-            //String인 경우 그대로 출력
-
-            if (modelAttribute != null) {
-                if (modelAttribute instanceof String) {
-                    sb.replace(startIndex, endIndex + CLOSING_TAG.length(),
-                        modelAttribute.toString());
-                    continue;
-                }
+            if (modelAttribute != null && modelAttribute instanceof String) {
+                sb.replace(startIndex, endIndex + CLOSING_TAG.length(),
+                    modelAttribute.toString());
+                continue;
             }
-            sb.replace(startIndex, endIndex + CLOSING_TAG.length(), "");
+            sb.replace(startIndex, endIndex + CLOSING_TAG.length(), EMPTY);
         }
-
     }
 
-    private static void renderBlock(StringBuilder sb, Object item) {
+
+    private static void renderBlockItem(StringBuilder sb, Object item)
+        throws InvocationTargetException, IllegalAccessException {
         while (sb.toString().contains(OPENING_TAG)) {
             int startIndex = sb.indexOf(OPENING_TAG);
             int endIndex = sb.indexOf(CLOSING_TAG);
             //Model 속성 이름을 찾는다.
             String fieldKey = sb.substring(startIndex + OPENING_TAG.length(), endIndex).trim();
 
-            if (item != null) {
-                Method getter = Arrays.stream(
-                        item.getClass().getDeclaredMethods())
-                    .filter(method -> method.getName().startsWith("get") && method.getName()
-                        .toLowerCase()
-                        .endsWith(fieldKey.toLowerCase()))
-                    .findFirst().orElseThrow(() -> {
-                        throw new IllegalArgumentException("존재하지 않는 모델입니다.");
-                    });
-                try {
-                    Object object = getter.invoke(item);
-                    sb.replace(startIndex, endIndex + CLOSING_TAG.length(),
-                        String.valueOf(object));
-                    continue;
-                } catch (IllegalAccessException |
-                         InvocationTargetException e) {
-                    throw new IllegalArgumentException();
-                }
-            }
-            sb.replace(startIndex, endIndex + CLOSING_TAG.length(), "");
+            Object field = invokeGetter(item, fieldKey);
+            sb.replace(startIndex, endIndex + CLOSING_TAG.length(), String.valueOf(field));
         }
+    }
 
+    private static Object invokeGetter(Object item, String fieldKey)
+        throws IllegalAccessException, InvocationTargetException {
+        Method getter = Arrays.stream(
+                item.getClass().getDeclaredMethods())
+            .filter(method -> method.getName().startsWith(GETTER)
+                && method.getName().toLowerCase().endsWith(fieldKey.toLowerCase()))
+            .findFirst()
+            .orElseThrow(() -> {
+                throw new IllegalArgumentException("존재하지 않는 모델입니다.");
+            });
+
+        return getter.invoke(item);
     }
 }
 

--- a/src/main/java/view/ModelAndView.java
+++ b/src/main/java/view/ModelAndView.java
@@ -1,5 +1,7 @@
 package view;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,6 +12,8 @@ public class ModelAndView {
     private String viewName;
     private ContentsType contentsType;
     private Map<String, Object> model = new HashMap<>();
+    private static final String TEMPLATE_DIR = "src/main/resources/templates";
+    private static final String STATIC_DIR = "src/main/resources/static";
 
     public ModelAndView setViewName(String viewName) {
         this.viewName = viewName;
@@ -29,9 +33,30 @@ public class ModelAndView {
         model.put(key, value);
     }
 
+    public boolean isDynamicFile() {
+        File templateFile = new File(TEMPLATE_DIR + viewName);
+        if (templateFile.exists()) {
+            return true;
+        }
+        return false;
+    }
 
-    public String getPath() {
-        return contentsType.getLocatedPath() + viewName;
+    public boolean isStaticFile() {
+        File staticFile = new File(STATIC_DIR + viewName);
+        if (staticFile.exists()) {
+            return true;
+        }
+        return false;
+    }
+
+    public File getFile() throws FileNotFoundException {
+        if (isDynamicFile()) {
+            return new File(TEMPLATE_DIR + viewName);
+        }
+        if (isStaticFile()) {
+            return new File(STATIC_DIR + viewName);
+        }
+        throw new FileNotFoundException("파일이 존재하지 않습니다.");
     }
 
     public boolean hasBody() {

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -3,6 +3,7 @@ package webserver;
 import java.net.ServerSocket;
 import java.net.Socket;
 
+import mapper.MappingInfoRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,8 @@ public class WebServer {
             logger.info("Web Application Server started {} port.", port);
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
+
+            MappingInfoRepository.initMapping();
 
             while ((connection = listenSocket.accept()) != null) {
                 connection.setSoTimeout(5000);

--- a/src/main/resources/templates/user/list.html
+++ b/src/main/resources/templates/user/list.html
@@ -83,11 +83,11 @@
                 </tr>
               </thead>
               <tbody>
-              ^Start^
+              ^# users #^
                 <tr>
-                    <th scope="row">^P user.index P^</th> <td>^P user.userId P^</td> <td>^P user.name P^</td> <td>^P user.email P^</td><td><a href="#" class="btn btn-success" role="button">수정</a></td>
+                    <th scope="row">^P index P^</th> <td>^P userId P^</td> <td>^P name P^</td> <td>^P email P^</td><td><a href="#" class="btn btn-success" role="button">수정</a></td>
                 </tr>
-              ^End^
+              ^/ users /^
               </tbody>
           </table>
         </div>


### PR DESCRIPTION
## 구현 내용
- 피드백 주셨던 path 필드를 삭제하고 리플렉션으로 templates 폴더 -> static 폴더 순으로 탐색해서 파일을 찾도록 변경했습니다. (html이 static과 template 두 가지가 모두 있을 수 있기 때문에 변경했습니다.)
- HandlerMapping, ExceptionMapping 로직을 MappingInfoRepository를 만들어서 컨트롤러에서 분리했습니다.
- 템플릿 엔진을 하드코딩으로 User타입에만 동작하도록 구현했었는데, 다른 분들의 코드를 참고해서 일반적인 List<타입>에도 동작하도록 로직을 수정했습니다. (가독성이 떨어지는 문법도 조금 바꿨습니다.)
  - Getter를 호출해서 데이터를 가져오도록 구현
- 브라우저가 유효한 세션을 보내고 있는지 모든 페이지에서 확인해야하는데 이 로직을 분리하기 위해서 Proxy와 cglib을 학습 후 인터셉터를 구현했습니다.

## 고민 사항
- 학습 과정을 통해서 스프링에서 어떤 방식으로 AOP가 구현되어있는지 조금 알게 되었습니다. 인터셉터를 구현하는 과정에서 스프링처럼 하나의 함수를 호출하기 전에 여러개의 인터셉터가 순차적으로 실행되도록 구현하고 싶었는데 reflection과 같이 사용하다보니 reflection의 메서드를 호출하면 프록시 클래스의 메서드가 호출되는 이슈가 있었습니다. 이를 superclass를 가져와서 해결했는데 인터셉터의 개수가 많아지면 superclass로 개수만큼 로직을 수정해주어야해서 하나의 인터셉터에 로깅과 세션 로직을 같이 넣어서 구현을 마무리했습니다. 
- Interceptor를 적용하니 Spring에서처럼 ExceptionHandler가 잡아주질 못했습니다. 프록시된 객체에서 target 객체를 Invoke하기 전에 예외가 발생하기 때문에 DispatcherServlet으로 예외가 throw되는 것 때문이었습니다. 스프링에서도 Interceptor에서 발생하는 예외처리가 까다로웠는데 비슷한 이유였던 것 같습니다.